### PR TITLE
Fix Issue With Random Number Being Outside Bounds

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ exports.generate = function () {
   var string = "";
   var chars =  ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
   for (var i = 0; i < 8; i++) {
-    string += chars[Math.floor(Math.random()*chars.length -1)];
+    string += chars[Math.floor(Math.random()*chars.length -1) % chars.length];
   };
   return string;
 };


### PR DESCRIPTION
This PR fixes an issue where a random number can be generated which is outside of the bounds of the `char` array. This way when a value is outside of the bounds of the array it is roped back into the valid bounds using the modulus function.
